### PR TITLE
fix minChangeNeg calculation for binance

### DIFF
--- a/markets-picker.sh
+++ b/markets-picker.sh
@@ -135,8 +135,8 @@ echo $(date +"%Y/%m/%d %H:%M:%S") "[INFO] 24h Percent Change Between: [ -15.00% 
 
         plusLimit=$(echo "15" | bc)
         minusLimit=$(echo "-15" | bc)
-        minChange=$(echo "$minChange*100" | bc)
         minChangeNeg=$(echo "-$minChange*100" | bc)
+        minChange=$(echo "$minChange*100" | bc)
         percChange=$(echo "$minChange" | bc)
 
         for market in $markets; do

--- a/markets-picker.sh
+++ b/markets-picker.sh
@@ -135,8 +135,8 @@ echo $(date +"%Y/%m/%d %H:%M:%S") "[INFO] 24h Percent Change Between: [ -15.00% 
 
         plusLimit=$(echo "15" | bc)
         minusLimit=$(echo "-15" | bc)
-        minChangeNeg=$(echo "-$minChange*100" | bc)
         minChange=$(echo "$minChange*100" | bc)
+        minChangeNeg=$(echo "-$minChange" | bc)
         percChange=$(echo "$minChange" | bc)
 
         for market in $markets; do


### PR DESCRIPTION
e.g. if minChange=0.05, it will be multiplied by 100, so minChange=5
then for minChangeNeg, it multiplies that value again, so minChangeNeg=-500
quite sure this isn't intended :)